### PR TITLE
Fix circular dependency between PatternParser and JSONParser

### DIFF
--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "Spatter/Configuration.hh"
-#include "Spatter/JSONParser.hh"
 #include "Spatter/SpatterTypes.hh"
 
 namespace Spatter {


### PR DESCRIPTION
Fixes a circular dependency between 'JSONParser.hh' and 'PatternParser.hh', resolving a compilation issue with an external repo's configure script when including Spatter headers.