### PR TITLE
Reset optind before calling getopt_long

### DIFF
--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -236,6 +236,7 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
   size_t delta_scatter = 8;
   size_t local_work_size;
 
+  optind = 1;
   int c;
   while ((c = getopt_long(argc, argv, shortargs, longargs, nullptr)) != -1) {
     switch (c) {


### PR DESCRIPTION
Ensures getopt_long begins parsing the arguments from the first element of the argv array, addressing a scenario where external source code may increment optind prior to Spatter calling getopt_long when including Spatter headers.