### PR TITLE
Updated CMake to identify Intel oneAPI compiler

### DIFF
--- a/cmake/CompilerType.cmake
+++ b/cmake/CompilerType.cmake
@@ -11,7 +11,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray")
     set(SPAT_CXX_NAME "Cray")
 endif ()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel") 
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Intel)(LLVM)?")
     set (OpenMP_CXX_FLAGS "${OpenMP_CXX_FLAGS} -xHost -qopenmp")
     set(SPAT_CXX_NAME "Intel")
 endif ()


### PR DESCRIPTION
CMake identifies the Intel compiler installed with Intel oneAPI as IntelLLVM. This PR resolves the issue where the conditional block for the Intel compiler is not executed when building with the Intel oneAPI compiler.