### PR TITLE
Fixed the number of bytes reported for GS patterns

### DIFF
--- a/src/Spatter/Configuration.cc
+++ b/src/Spatter/Configuration.cc
@@ -54,7 +54,7 @@ void ConfigurationBase::report() {
     total_bytes_moved = nruns * pattern.size() * count * sizeof(size_t);
 
   if (kernel.compare("sg") == 0)
-    total_bytes_moved = nruns * pattern_gather.size() * count * sizeof(size_t);
+    total_bytes_moved = nruns * (pattern_scatter.size() + pattern_gather.size()) * count * sizeof(size_t);
 
   if (kernel.compare("multiscatter") == 0)
     total_bytes_moved = nruns * pattern_scatter.size() * count * sizeof(size_t);


### PR DESCRIPTION
The number of bytes reported for GS patterns was not consistent with the current Spatter version.

https://github.com/JDTruj2018/spatter/blob/d9233fe8810ba439e7d1720d0c6526798497e5ed/src/main.c#L145-L152