### PR TITLE
Negative deltas in JSON files are set to the default value

### DIFF
--- a/src/Spatter/JSONParser.cc
+++ b/src/Spatter/JSONParser.cc
@@ -55,13 +55,13 @@ JSONParser::JSONParser(std::string filename, const std::string backend,
       }
     }
 
-    if (!v.contains("delta"))
+    if (!v.contains("delta") || (v["delta"] <= -1))
       v["delta"] = default_delta_;
 
-    if (!v.contains("delta-gather"))
+    if (!v.contains("delta-gather") || (v["delta-gather"] <= -1))
       v["delta-gather"] = default_delta_gather_;
 
-    if (!v.contains("delta-scatter"))
+    if (!v.contains("delta-scatter") || (v["delta-scatter"] <= -1))
       v["delta-scatter"] = default_delta_scatter_;
 
     if (!v.contains("seed"))


### PR DESCRIPTION
This PR resolves an issue with negative delta values in JSON input files. To maintain consistency with the current Spatter version, the default value of 8 is now used when a negative delta value is specified for a run config in JSON input files. This change allows the LULESH and Nekbone traces to run.