### PR TITLE
Fixes Pattern Parsing

### DIFF
--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -233,7 +233,7 @@ int read_ul_arg(std::string cl, size_t &arg, const std::string &err_msg) {
     std::cerr << err_msg << std::endl;
     return -1;
   } else {
-    arg = passed_arg;
+    arg = static_cast<size_t>(passed_arg);
   }
 
   return 0;

--- a/src/Spatter/PatternParser.cc
+++ b/src/Spatter/PatternParser.cc
@@ -88,293 +88,152 @@ int generate_pattern_uniform(std::string args,
       delta = len*stride;
     }
 
-    /*
-    std::cout << "len: " << len << std::endl;
-    std::cout << "stride: " << stride << std::endl;
-    std::cout << "delta: " << delta << std::endl;
-    std::cout << "delta_str: " << delta_str << std::endl;
-
-    exit(1);
-    */
-
-    /*
-    for (std::string line; std::getline(pattern_string, line, ':');) {
-      try {
-        size_t val = std::stoul(line);
-
-
-        if (line[0] == '-') {
-          std::cerr
-              << "Parsing Error: Found Negative Index in Pattern Generator"
-              << std::endl;
-          return -1;
-        } else {
-          std::vector<size_t> values;
-          values.push_back(val);
-          generator.push_back(values);
-        }
-      } catch (const std::invalid_argument &ia) {
-        if (line.compare("NR") == 0) {
-          std::cout << "Found NR but ignoring it\n";
-        }
-      }
-    }
-
-    if (generator.size() != 2 || generator.size() != 3) {
-      std::cerr << "Parsing Error: Invalid UNIFORM Pattern "
-                   "(UNIFORM:<length>:<stride>[:NR])"
-                << std::endl;
-      return -1;
-    }
-
-    size_t len = generator[0][0];
-    size_t stride = generator[1][0];
-    */
-
     for (size_t i = 0; i < len; ++i)
       pattern.push_back(i * stride);
 
     return 0;
 }
 
-int generate_pattern_ms1(std::vector<std::vector<size_t>> generator,
-    aligned_vector<size_t> &pattern,
-    size_t &delta) {
-    if (generator.size() != 3) {
-      std::cerr << "Parsing Error: Invalid MS1 Pattern "
-                   "(MS1:<length>:<gap_locations>:<gap(s)>)"
-                << std::endl;
-      return -1;
-    }
+int generate_pattern_ms1(std::string args,
+    aligned_vector<size_t> &pattern) {
+    // if (generator.size() != 3) {
+    //   std::cerr << "Parsing Error: Invalid MS1 Pattern "
+    //                "(MS1:<length>:<gap_locations>:<gap(s)>)"
+    //             << std::endl;
+    //   return -1;
+    // }
 
-    size_t len = 0;
-    std::vector<size_t> gap_locations;
-    std::vector<size_t> gaps;
-    for (size_t i = 0; i < generator.size(); ++i) {
-      if (i == 0)
-        len = generator[i][0];
-      if (i == 1)
-        for (size_t j = 0; j < generator[i].size(); ++j)
-          gap_locations.push_back(generator[i][j]);
-      if (i == 2)
-        for (size_t j = 0; j < generator[i].size(); ++j)
-          gaps.push_back(generator[i][j]);
-    }
+    // size_t len = 0;
+    // std::vector<size_t> gap_locations;
+    // std::vector<size_t> gaps;
+    // for (size_t i = 0; i < generator.size(); ++i) {
+    //   if (i == 0)
+    //     len = generator[i][0];
+    //   if (i == 1)
+    //     for (size_t j = 0; j < generator[i].size(); ++j)
+    //       gap_locations.push_back(generator[i][j]);
+    //   if (i == 2)
+    //     for (size_t j = 0; j < generator[i].size(); ++j)
+    //       gaps.push_back(generator[i][j]);
+    // }
 
-    if (gap_locations.size() > 1 && gaps.size() != gap_locations.size() &&
-        gaps.size() != 1) {
-      std::cerr << "Parsing Error: Invalid MS1 Pattern "
-                   "(MS1:<length>:<gap_locations>:<gap(s)>)"
-                << std::endl;
-      return -1;
-    }
+    // if (gap_locations.size() > 1 && gaps.size() != gap_locations.size() &&
+    //    td::cerr << "Parsing Error: Invalid MS1 Pattern "
+    //                "(MS1:<length>:<gap_locations>:<gap(s)>)"
+    //             << std::endl;
+    //   return -1;
+    // }
 
-    size_t val = -1;
-    size_t gap_index = 0;
-    for (size_t i = 0; i < len; ++i) {
-      if (gap_index < gap_locations.size() && gap_locations[gap_index] == i) {
-        if (gaps.size() > 1)
-          val += gaps[gap_index];
-        else
-          val += gaps[0];
-        gap_index++;
-      } else
-        val++;
+    // int64_t val = -1;
+    // size_t gap_index = 0;
+    // for (size_t i = 0; i < len; ++i) {
+    //   if (gap_index < gap_locations.size() && gap_locations[gap_index] == i) {
+    //     if (gaps.size() > 1)
+    //       val += gaps[gap_index];
+    //     else
+    //       val += gaps[0];
+    //     gap_index++;
+    //   } else
+    //     val++;
 
-      pattern.push_back(val);
-    }
-    return 0;
-}
-int generate_pattern_laplacian(std::vector<std::vector<size_t>> generator,
-    aligned_vector<size_t> &pattern,
-    size_t &delta) {
+    //   pattern.push_back(static_cast<size_t>(val));
+    // }
+    // return 0; gaps.size() != 1) {
+    //   std::cerr << "Parsing Error: Invalid MS1 Pattern "
+    //                "(MS1:<length>:<gap_locations>:<gap(s)>)"
+    //             << std::endl;
+    //   return -1;
+    // }
 
-    if (generator.size() != 3) {
-      std::cerr << "Parsing Error: Invalid LAPLACIAN Pattern "
-                   "(LAPLACIAN:<dimension>:<pseudo_order>:<problem_size>)"
-                << std::endl;
-      return -1;
-    }
+    // int64_t val = -1;
+    // size_t gap_index = 0;
+    // for (size_t i = 0; i < len; ++i) {
+    //   if (gap_index < gap_locations.size() && gap_locations[gap_index] == i) {
+    //     if (gaps.size() > 1)
+    //       val += gaps[gap_index];
+    //     else
+    //       val += gaps[0];
+    //     gap_index++;
+    //   } else
+    //     val++;
 
-    size_t dimension = generator[0][0];
-    size_t pseudo_order = generator[1][0];
-    size_t problem_size = generator[2][0];
-
-    if (dimension < 1) {
-      std::cerr << "Parsing Error: Invalid LAPLACIAN Pattern, Dimension must "
-                   "be positive"
-                << std::endl;
-      return -1;
-    }
-
-    size_t final_len = dimension * pseudo_order * 2 + 1;
-    size_t pos_len = 0;
-
-    std::vector<size_t> pos;
-
-    for (size_t i = 0; i < dimension; ++i) {
-      for (size_t j = 0; j < pseudo_order; ++j) {
-        pos.push_back((j + 1) * power(problem_size, i));
-      }
-      pos_len += pseudo_order;
-    }
-
-    size_t max = pos[pos_len - 1];
-
-    for (size_t i = 0; i < final_len; ++i)
-      pattern.push_back(2);
-
-    for (size_t i = 0; i < pos_len; ++i)
-      pattern[i] = -pos[pos_len - i - 1] + max;
-
-    pattern[pos_len] = max;
-
-    for (size_t i = 0; i < pos_len; ++i)
-      pattern[pos_len + 1 + i] = pos[i] + max;
-
+    //   pattern.push_back(static_cast<size_t>(val));
+    // }
     return 0;
 }
 
-int pattern_parser(
-    std::stringstream &pattern_string, aligned_vector<size_t> &pattern, size_t &delta) {
+int generate_pattern_laplacian(std::string args,
+    aligned_vector<size_t> &pattern) {
+    // if (generator.size() != 3) {
+    //   std::cerr << "Parsing Error: Invalid LAPLACIAN Pattern "
+    //                "(LAPLACIAN:<dimension>:<pseudo_order>:<problem_size>)"
+    //             << std::endl;
+    //   return -1;
+    // }
 
+    // size_t dimension = generator[0][0];
+    // size_t pseudo_order = generator[1][0];
+    // size_t problem_size = generator[2][0];
+
+    // if (dimension < 1) {
+    //   std::cerr << "Parsing Error: Invalid LAPLACIAN Pattern, Dimension must "
+    //                "be positive"
+    //             << std::endl;
+    //   return -1;
+    // }
+
+    // size_t final_len = dimension * pseudo_order * 2 + 1;
+    // size_t pos_len = 0;
+
+    // std::vector<size_t> pos;
+
+    // for (size_t i = 0; i < dimension; ++i) {
+    //   for (size_t j = 0; j < pseudo_order; ++j) {
+    //     pos.push_back((j + 1) * power(problem_size, i));
+    //   }
+    //   pos_len += pseudo_order;
+    // }
+
+    // size_t max = pos[pos_len - 1];
+
+    // for (size_t i = 0; i < final_len; ++i)
+    //   pattern.push_back(2);
+
+    // for (size_t i = 0; i < pos_len; ++i)
+    //   pattern[i] = -pos[pos_len - i - 1] + max;
+
+    // pattern[pos_len] = max;
+
+    // for (size_t i = 0; i < pos_len; ++i)
+    //   pattern[pos_len + 1 + i] = pos[i] + max;
+
+    return 0;
+}
+
+int pattern_parser(std::stringstream &pattern_string,
+    aligned_vector<size_t> &pattern,
+    size_t &delta) {
   std::string type;
   std::string args;
 
   std::getline(pattern_string, type, ':');
   std::getline(pattern_string, args);
 
-  if (type.compare("UNIFORM") == 0) {
-    return generate_pattern_uniform(args, pattern, delta);
-  } else if (type.compare("MS1") == 0) {
-    //return generate_pattern_ms1(args, pattern, delta);
-    return 0;
-  } else if (type.compare("LAPLACIAN") == 0) {
-    //return generate_pattern_laplacian(args, pattern, delta);
-    return 0;
-  } else {
+  int ret = -1;
+
+  if (type.compare("UNIFORM") == 0)
+    ret = generate_pattern_uniform(args, pattern, delta);
+  else if (type.compare("MS1") == 0)
+    ret = generate_pattern_ms1(args, pattern);
+  else if (type.compare("LAPLACIAN") == 0)
+    ret = generate_pattern_laplacian(args, pattern);
+  else
     std::cerr << "Parsing Error: Invalid Pattern Generator Type (Valid types "
                  "are: UNIFORM, MS1, LAPLACIAN)"
               << std::endl << "Recieved: " << type << std::endl;
-  return -1;
-  }
-  // Unreachable
+
+  return ret;
 }
-/*
-
-  std::getline(pattern_string, type, ':');
-  std::getline(pattern_string, args);
-  std::cout << "type: " << type << std::endl;
-  std::cout << "args: " << args << std::endl;
-  exit(1);
-  std::vector<std::vector<size_t>> generator;
-
-  if (pattern_string.str().rfind("UNIFORM", 0) == 0) {
-    std::getline(pattern_string, type, ':');
-
-    for (std::string line; std::getline(pattern_string, line, ':');) {
-      try {
-        size_t val = std::stoul(line);
-
-
-        if (line[0] == '-') {
-          std::cerr
-              << "Parsing Error: Found Negative Index in Pattern Generator"
-              << std::endl;
-          return -1;
-        } else {
-          std::vector<size_t> values;
-          values.push_back(val);
-          generator.push_back(values);
-        }
-      } catch (const std::invalid_argument &ia) {
-        if (line.compare("NR") == 0) {
-          std::cout << "Found NR but ignoring it\n";
-        }
-      }
-    }
-  } else if (pattern_string.str().rfind("MS1", 0) == 0) {
-    std::getline(pattern_string, type, ':');
-
-    for (std::string line; std::getline(pattern_string, line, ':');) {
-      try {
-        std::vector<size_t> values;
-
-        std::stringstream linestream;
-        linestream << line;
-        for (std::string subline; std::getline(linestream, subline, ',');) {
-          try {
-            size_t val = std::stoul(subline);
-
-            if (subline[0] == '-') {
-              std::cerr << "Parsing Error: Found Negative Index in Pattern"
-                        << std::endl;
-              return -1;
-            } else
-              values.push_back(val);
-          } catch (const std::invalid_argument &ia) {
-            std::cerr << "Parsing Error: Invalid Pattern Generator Format"
-                      << std::endl;
-            return -1;
-          }
-        }
-        generator.push_back(values);
-      } catch (const std::invalid_argument &ia) {
-        std::cerr << "Parsing Error: Invalid Pattern Generator Format"
-                  << std::endl;
-        return -1;
-      }
-    }
-  } else if (pattern_string.str().rfind("LAPLACIAN", 0) == 0) {
-    std::getline(pattern_string, type, ':');
-
-    for (std::string line; std::getline(pattern_string, line, ':');) {
-      try {
-        size_t val = std::stoul(line);
-
-        if (line[0] == '-') {
-          std::cerr
-              << "Parsing Error: Found Negative Index in Pattern Generator"
-              << std::endl;
-          return -1;
-        } else {
-          std::vector<size_t> values;
-          values.push_back(val);
-          generator.push_back(values);
-        }
-      } catch (const std::invalid_argument &ia) {
-        std::cerr << "Parsing Error: Invalid Pattern Generator Format"
-                  << std::endl;
-        return -1;
-      }
-    }
-  }
-
-  if (!type.empty())
-    if (generate_pattern(type, generator, pattern, delta) != 0)
-      return -1;
-
-  if (type.empty()) {
-    for (std::string line; std::getline(pattern_string, line, ',');) {
-      try {
-        size_t val = std::stoul(line);
-
-        if (line[0] == '-') {
-          std::cerr << "Parsing Error: Found Negative Index in Pattern"
-                    << std::endl;
-          return -1;
-        } else
-          pattern.push_back(val);
-      } catch (const std::invalid_argument &ia) {
-        std::cerr << "Parsing Error: Invalid Pattern Format" << std::endl;
-        return -1;
-      }
-    }
-  }
-
-  return 0;
-}
-*/
 
 size_t remap_pattern(aligned_vector<size_t> &pattern, const size_t boundary) {
   const size_t pattern_len = pattern.size();

--- a/src/Spatter/PatternParser.cc
+++ b/src/Spatter/PatternParser.cc
@@ -37,6 +37,29 @@ void compress_pattern(aligned_vector<size_t> &pattern) {
   }
 }
 
+int generate_pattern_custom(std::string pattern_string,
+    aligned_vector<size_t> &pattern) {
+  try {
+    std::stringstream linestream(pattern_string);
+    std::string line;
+
+    while (std::getline(linestream, line, ',')) {
+      int64_t value = stoll(line);
+
+      if (value < 0)
+        throw std::invalid_argument("Negative value");
+
+      pattern.push_back(static_cast<size_t>(value));
+    }
+
+  } catch (const std::invalid_argument &ia) {
+    std::cerr << "Parsing Error: Invalid Pattern Format" << std::endl;
+    return -1;
+  }
+
+  return 0;
+}
+
 int generate_pattern_uniform(std::vector<std::string> args,
     aligned_vector<size_t> &pattern,
     size_t &delta) {
@@ -235,6 +258,7 @@ int pattern_parser(std::stringstream &pattern_string,
     args.push_back(line);
 
   int ret = -1;
+  std::regex rgx(CUSTOM_PATTERN);
 
   if (type.compare("UNIFORM") == 0)
     ret = generate_pattern_uniform(args, pattern, delta);
@@ -242,6 +266,8 @@ int pattern_parser(std::stringstream &pattern_string,
     ret = generate_pattern_ms1(args, pattern);
   else if (type.compare("LAPLACIAN") == 0)
     ret = generate_pattern_laplacian(args, pattern, delta);
+  else if (std::regex_match(type.begin(), type.end(), rgx))
+    ret = generate_pattern_custom(type, pattern);
   else
     std::cerr << "Parsing Error: Invalid Pattern Generator Type (Valid types "
                  "are: UNIFORM, MS1, LAPLACIAN)"

--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -15,7 +15,7 @@
 #include "Configuration.hh"
 #include "SpatterTypes.hh"
 
-#define CUSTOM_PATTERN "(^[0-9]+)(,[0-9])*$"
+#define CUSTOM_PATTERN "(^[0-9]+)(,[0-9]+)*$"
 #define PAGE_BITS 12 // 12 bits => 4 KiB page
 
 namespace Spatter {

--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -30,7 +30,8 @@ int generate_pattern_ms1(std::vector<std::string> args,
     aligned_vector<size_t> &pattern);
 
 int generate_pattern_laplacian(std::vector<std::string> args,
-    aligned_vector<size_t> &pattern);
+    aligned_vector<size_t> &pattern,
+    size_t &delta);
 
 int pattern_parser(std::stringstream &pattern_string,
     aligned_vector<size_t> &pattern,

--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -22,14 +22,14 @@ size_t power(size_t base, size_t exp);
 
 void compress_pattern(aligned_vector<size_t> &pattern);
 
-int generate_pattern_uniform(std::string args,
+int generate_pattern_uniform(std::vector<std::string> args,
     aligned_vector<size_t> &pattern,
     size_t &delta);
 
-int generate_pattern_ms1(std::string args,
+int generate_pattern_ms1(std::vector<std::string> args,
     aligned_vector<size_t> &pattern);
 
-int generate_pattern_laplacian(std::string args,
+int generate_pattern_laplacian(std::vector<std::string> args,
     aligned_vector<size_t> &pattern);
 
 int pattern_parser(std::stringstream &pattern_string,

--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "Configuration.hh"
 #include "SpatterTypes.hh"
 
+#define CUSTOM_PATTERN "(^[0-9]+)(,[0-9])*$"
 #define PAGE_BITS 12 // 12 bits => 4 KiB page
 
 namespace Spatter {
@@ -21,6 +23,9 @@ namespace Spatter {
 size_t power(size_t base, size_t exp);
 
 void compress_pattern(aligned_vector<size_t> &pattern);
+
+int generate_pattern_custom(std::string pattern_string,
+    aligned_vector<size_t> &pattern);
 
 int generate_pattern_uniform(std::vector<std::string> args,
     aligned_vector<size_t> &pattern,

--- a/src/Spatter/PatternParser.hh
+++ b/src/Spatter/PatternParser.hh
@@ -22,12 +22,19 @@ size_t power(size_t base, size_t exp);
 
 void compress_pattern(aligned_vector<size_t> &pattern);
 
-int generate_pattern(std::string type,
-    std::vector<std::vector<size_t>> generator,
+int generate_pattern_uniform(std::string args,
+    aligned_vector<size_t> &pattern,
+    size_t &delta);
+
+int generate_pattern_ms1(std::string args,
     aligned_vector<size_t> &pattern);
 
-int pattern_parser(
-    std::stringstream &pattern_string, aligned_vector<size_t> &pattern, size_t &delta);
+int generate_pattern_laplacian(std::string args,
+    aligned_vector<size_t> &pattern);
+
+int pattern_parser(std::stringstream &pattern_string,
+    aligned_vector<size_t> &pattern,
+    size_t &delta);
 
 size_t remap_pattern(aligned_vector<size_t> &pattern, const size_t boundary);
 


### PR DESCRIPTION
This PR resolves the following issues:

- UNIFORM patterns could be provided more than three arguments
- Negative size_t value in MS1 pattern parsing
- MS1 pattern parsing moved to new function and left unfinished
- LAPLACIAN pattern parsing moved to new function and left unfinished
- MS1 patterns could be provided more gaps than gap locations
- CUSTOM pattern parsing was removed
- Ensure explicit casting from int64_t to size_t